### PR TITLE
A small patch to prevent possible armor dupe

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/dummmmmmy/common/TargetDummyEntity.java
+++ b/common/src/main/java/net/mehvahdjukaar/dummmmmmy/common/TargetDummyEntity.java
@@ -304,7 +304,7 @@ public class TargetDummyEntity extends Mob {
     }
 
     public void dismantle(boolean drops) {
-        if (!this.level.isClientSide) {
+        if (!this.level.isClientSide && this.isAlive()) {
             if (drops) {
                 this.dropEquipment();
                 this.spawnAtLocation(Dummmmmmy.DUMMY_ITEM.get(), 1);


### PR DESCRIPTION
This wouldn't occur normally, but with other mods which, for example, add damage from another DamageSource to player's punches, shift-attacking a dummy causes TargetDummyEntity#hurt (and, in turn, TargetDummyEntity#dismantle) to be called twice, duping the items equipped.
Sorry for not testing it myself and leaving it to you ;_; I only have 1.16.5 Forge mdk and my hard drive space is tight. Though I believe this patch should do the trick.