### PR TITLE
Fix and improve damage numbers

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/dummmmmmy/configs/CommonConfigs.java
+++ b/common/src/main/java/net/mehvahdjukaar/dummmmmmy/configs/CommonConfigs.java
@@ -4,8 +4,6 @@ import net.mehvahdjukaar.dummmmmmy.Dummmmmmy;
 import net.mehvahdjukaar.moonlight.api.platform.configs.ConfigBuilder;
 import net.mehvahdjukaar.moonlight.api.platform.configs.ConfigSpec;
 import net.mehvahdjukaar.moonlight.api.platform.configs.ConfigType;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.player.Player;
 
 import java.util.Collections;
 import java.util.List;
@@ -26,20 +24,11 @@ public class CommonConfigs {
     public static final Supplier<Boolean> DECOY;
     public static final Supplier<DpsMode> DYNAMIC_DPS;
     public static final Supplier<Integer> MAX_COMBAT_INTERVAL;
-
-    public static final Supplier<Boolean> EXTRA_DAMAGE_NUMBERS;
-    public static final Supplier<Mode> MODE;
+    public static final Supplier<Mode> DAMAGE_NUMBERS_MODE;
+    public static final Supplier<Mode> HEALING_NUMBERS_MODE;
 
     public enum Mode {
-        ALL_ENTITIES, ALL_PLAYERS, LOCAL_PLAYER;
-
-        public boolean canSee(Entity e) {
-            return switch (this) {
-                case ALL_PLAYERS -> e instanceof Player;
-                case LOCAL_PLAYER -> e instanceof Player p && p.isLocalPlayer();
-                case ALL_ENTITIES -> true;
-            };
-        }
+        ALL_ENTITIES, ALL_PLAYERS, LOCAL_PLAYER, NONE;
     }
 
     static {
@@ -72,8 +61,10 @@ public class CommonConfigs {
         builder.pop();
 
         builder.push("mobs_damage_numbers");
-        EXTRA_DAMAGE_NUMBERS = builder.define("enabled", false);
-        MODE = builder.define("mode", Mode.ALL_ENTITIES);
+        DAMAGE_NUMBERS_MODE = builder.comment("Show damage taken form")
+                .define("damage_mode", Mode.ALL_ENTITIES);
+        HEALING_NUMBERS_MODE = builder.comment("Show healing taken for")
+                .define("healing_mode", Mode.ALL_ENTITIES);
         builder.pop();
 
         SPEC = builder.buildAndRegister();

--- a/common/src/main/java/net/mehvahdjukaar/dummmmmmy/mixins/PlayerMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/dummmmmmy/mixins/PlayerMixin.java
@@ -1,0 +1,26 @@
+package net.mehvahdjukaar.dummmmmmy.mixins;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.mehvahdjukaar.dummmmmmy.common.ModEvents;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(Player.class)
+public class PlayerMixin {
+
+    @WrapOperation(method = "actuallyHurt", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;setHealth(F)V"))
+    private void actuallyHurt_setHealth(
+            // Mixin parameters
+            Player entity, float healthToSet, Operation<Void> original,
+            // Context parameters
+            DamageSource damageSource, float damageAmount
+    ) {
+        var originalHealth = entity.getHealth();
+        var mitigatedDamageAmount = originalHealth - healthToSet;
+        ModEvents.onEntityDamage(entity, mitigatedDamageAmount, damageSource);
+        original.call(entity, healthToSet);
+    }
+}

--- a/common/src/main/java/net/mehvahdjukaar/dummmmmmy/network/ClientBoundDamageNumberMessage.java
+++ b/common/src/main/java/net/mehvahdjukaar/dummmmmmy/network/ClientBoundDamageNumberMessage.java
@@ -67,8 +67,7 @@ public class ClientBoundDamageNumberMessage implements Message {
                 spawnParticle(entity, i);
             }
         } else if (entity != null) {
-            if(CommonConfigs.MODE.get().canSee(entity))
-                spawnParticle(entity, 0);
+            spawnParticle(entity, 0);
         }
     }
 

--- a/common/src/main/resources/dummmmmmy-common.mixins.json
+++ b/common/src/main/resources/dummmmmmy-common.mixins.json
@@ -7,6 +7,7 @@
   ],
   "mixins": [
     "LivingEntityMixin",
+    "PlayerMixin",
     "SwordItemMixin",
     "ToolItemMixin"
   ],


### PR DESCRIPTION
Changes:
- Fixed showing damage done on Players (required additional Mixin, due to Player class override)
- Server decides how damage particles are sent out (so potential performance impact can be mitigated)
- Fixed logic
- Damage and Healing numbers can be configured to be shown independently
- Removed `EXTRA_DAMAGE_NUMBERS` config, replaced by `Mode.NONE`